### PR TITLE
Add readyQueue to AirgapAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "6.8.1",
+  "version": "6.8.2",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -123,6 +123,8 @@ export type PrivacyRegime = t.TypeOf<typeof PrivacyRegime>;
 export type AirgapAPI = Readonly<{
   /** Airgap ready event subscriber */
   ready(callback: (airgap: AirgapAPI) => void): void;
+  /** Queue of callbacks to dispatch once airgap is ready */
+  readyQueue?: ((airgap: AirgapAPI) => void)[];
   /** Enqueue cross-domain data sync across all airgap bundle domains */
   sync(): Promise<void>;
   /** Resolve airgap request overrides for a URL */


### PR DESCRIPTION
## Related Issues

- We need access to `readyQueue` in the consent-manager-ui module

## Security Implications

_[none]_

## System Availability

_[none]_
