### PR TITLE
Don't rely on `airgap.resolve()` returning a `string`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "6.8.14",
+  "version": "6.8.16",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -128,7 +128,7 @@ export type AirgapAPI = Readonly<{
   /** Enqueue cross-domain data sync across all airgap bundle domains */
   sync(): Promise<void>;
   /** Resolve airgap request overrides for a URL */
-  resolve(url: Stringifiable): string;
+  resolve(url: Stringifiable): Stringifiable;
   /** Get tracking consent */
   getConsent(): TrackingConsentDetails;
   /** Set tracking consent */


### PR DESCRIPTION
airgap.js may propagate non-string `Stringifiable`s (e.g. [`URL`s](https://developer.mozilla.org/en-US/docs/Web/API/URL) and [`TrustedScriptURL`s](https://developer.mozilla.org/en-US/docs/Web/API/TrustedScriptURL)) if request overrides make no changes to request input.

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
