### PR TITLE
`airgap.getRegimes()` and `airgap.getPrivacySignals()` are now synchronous

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "6.8.17",
+  "version": "7.0.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -164,9 +164,9 @@ export type AirgapAPI = Readonly<{
     autoReload?: boolean,
   ): boolean;
   /** Get a list of legal regimes that are potentially applicable to the user */
-  getRegimes(): Promise<Set<PrivacyRegime>>;
+  getRegimes(): Set<PrivacyRegime>;
   /** Get a list of detected active user agent privacy signals */
-  getPrivacySignals(): Promise<Set<UserPrivacySignal>>;
+  getPrivacySignals(): Set<UserPrivacySignal>;
   /** airgap.js version number */
   version: string;
 }> &


### PR DESCRIPTION
The initial thought behind making these methods async was to make it so that they could pull from an async data source at runtime (e.g. post-init runtime geoip). I found that these functions are always called at init-time, so I;ve have decided to make these APIs synchronous. This will aid ease of use for custom UI builders<!-- including myself: https://github.com/transcend-io/consent-manager-ui/pull/27 -->.

In order to seed regimes based on geoip data, you can dynamically annotate `data-regime="[inferred regime]"` on your airgap.js script tag from your backend.

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
