### PR TITLE
Revert "Add UCPA regime"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,6 +49,7 @@
     "Proteção",
     "Stringifiable",
     "tsbuildinfo",
+    "UCPA",
     "yarnpkg"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -49,7 +49,6 @@
     "Proteção",
     "Stringifiable",
     "tsbuildinfo",
-    "UCPA",
     "yarnpkg"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "8.10.2",
+  "version": "8.10.4",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "8.10.3",
+  "version": "8.10.2",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/enums/privacyRegime.ts
+++ b/src/enums/privacyRegime.ts
@@ -12,6 +12,4 @@ export enum PrivacyRegimeEnum {
   CDPA = 'CDPA',
   /** Colorado Privacy Act */
   CPA = 'CPA',
-  /** Utah Consumer Privacy Act */
-  UCPA = 'UCPA',
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -150,13 +150,10 @@ export const DEFAULT_VIEW_STATE_BY_PRIVACY_REGIME: PrivacyRegimeToInitialViewSta
     GDPR: InitialViewState.QuickOptions,
     // Brazil
     LGPD: InitialViewState.QuickOptions,
-    // Virginia
+    // Virginia (unreachable as we don't detect this regime yet)
     CDPA: InitialViewState.NoticeAndDoNotSell,
-    // Colorado
+    // Colorado (unreachable as we don't detect this regime yet)
     CPA: InitialViewState.NoticeAndDoNotSell,
-    // Utah
-    // TODO: https://transcend.height.app/T-17644 - change Utah default view state once UCPA is in effect
-    UCPA: InitialViewState.Hidden,
     // Other
     Unknown: InitialViewState.Hidden,
   };


### PR DESCRIPTION
Reverts transcend-io/airgap.js-types#31, will add this back in later after UI customization changes go out.