### PR TITLE
Improve dev UX for `airgap.getRegimePurposes()`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "8.10.4",
+  "version": "8.12.1",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -165,7 +165,7 @@ export type AirgapAPI = Readonly<{
   /** Returns true if the user is fully-opted out to all first-order tracking purposes */
   isOptedOut(): boolean;
   /** Resolve regime tracking purposes. If no regimes are provided, then the user's detected regimes are used */
-  getRegimePurposes(regimes?: PrivacyRegime[]): Set<TrackingPurpose>;
+  getRegimePurposes(regimes?: Set<PrivacyRegime>): Set<TrackingPurpose>;
   /** Get initialized tracking purposes config */
   getPurposeTypes(): TrackingPurposesTypes;
   /** Clear airgap queue & caches. Returns `true` on success. */


### PR DESCRIPTION
The optional `regimes` argument for `airgap.getRegimePurposes(regimes)` has been changed from an array to a set (the return type of `airgap.getRegimes()`). We don't use this optional argument in our UI module or anywhere else, so this is a safe change to make.

## Related Issues

- _[none]_

## Security Implications

_[none]_

## System Availability

_[none]_
