### PR TITLE
New consent manager UI types

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "8.18.0",
+  "version": "8.19.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/enums/viewState.ts
+++ b/src/enums/viewState.ts
@@ -7,14 +7,20 @@ import { makeEnum } from '@transcend-io/type-utils';
 export const InitialViewState = makeEnum({
   /* expanded and showing quick select options */
   QuickOptions: 'QuickOptions',
+  /* three option UI: essential, functional/analytics, advertising */
+  QuickOptions3: 'QuickOptions3',
   /* accept all or more options */
   AcceptAll: 'AcceptAll',
   /* accept all or reject all */
   AcceptOrRejectAll: 'AcceptOrRejectAll',
   /* data collection notice with do not sell */
   NoticeAndDoNotSell: 'NoticeAndDoNotSell',
+  /* open a modal that allows for an explanation of do not sell/share, before opting out */
+  DoNotSellNotice: 'DoNotSellNotice',
   /* notice that do not sell has been acknowledged properly */
   DoNotSellDisclosure: 'DoNotSellDisclosure',
+  /* open a modal that shows a notice that the privacy policy has changed, without any prompt to change consent */
+  PrivacyPolicyNotice: 'PrivacyPolicyNotice',
   /* expanded and showing full checkbox options */
   CompleteOptions: 'CompleteOptions',
   /* hidden */


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-20520
- links https://transcend.height.app/T-20359
- links https://transcend.height.app/T-20447

Three new UI states:

1) QuickOptions3 - Same as QuickOptions but merging functional/analytics
2) DoNotSellNotice - Opens a modal for do not sell, but opt out requires an additional confirmation after opening the modal
3) PrivacyPolicyNotice - Opens a modal with no consent options, but gives customer the ability to include free-from HTML text. This is useful for notifying website visitors that the privacy policy has changed.