### PR TITLE
Fix ConsentOptions to match change in metadata type

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "9.4.1",
+  "version": "9.4.2",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -141,7 +141,7 @@ export interface ConsentOptions {
    * - `null` - Do not change metadata
    * - `false` - Clear metadata
    */
-  metadata?: unknown | null | false;
+  metadata?: Record<string, unknown> | null | false;
   /** Whether or not to return a Promise so that the caller can wait for sync to complete. By default, we do not wait for sync */
   waitForSync?: boolean;
 }


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-24658
- Forgot to update `ConsentOptions` after changing `metadata` type https://github.com/transcend-io/airgap.js-types/pull/75

## Security Implications

_[none]_

## System Availability

_[none]_
