### PR TITLE
Add timestamps to ConsentOptions

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -142,8 +142,12 @@ export interface ConsentOptions {
    * - `false` - Clear metadata
    */
   metadata?: Record<string, unknown> | null | false;
+  /** Last updated for metadata */
+  metadataTimestamp?: string;
   /** Whether or not to return a Promise so that the caller can wait for sync to complete. By default, we do not wait for sync */
   waitForSync?: boolean;
+  /** Last updated */
+  timestamp?: string;
 }
 
 /** airgap.js API */


### PR DESCRIPTION
## Related Issues

- PR https://github.com/transcend-io/main/pull/22831 adds the ability to set timestamps for consent and metadata in `setConsent()` so adding `timestamp` and `metadataTimestamp` to reflect pending change

## Security Implications

_[none]_

## System Availability

_[none]_
