### PR TITLE
Make the `transcend` API object an EventTarget

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "9.6.0",
+  "version": "10.0.0-alpha.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.0.0-alpha.0",
+  "version": "10.0.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -33,7 +33,7 @@ export interface ShowConsentManagerOptions {
 /**
  * Transcend Consent Manager external methods
  */
-export type ConsentManagerAPI = {
+export type ConsentManagerAPI = Readonly<{
   /** Possible ViewState values */
   viewStates: Set<ViewState>;
   /** Expose an option to grab the current view state */
@@ -58,6 +58,18 @@ export type ConsentManagerAPI = {
     auth: AirgapAuth,
     options?: ShowConsentManagerOptions,
   ): Promise<void>;
+}> &
+  EventTarget;
+
+/**
+ * `transcend` event type
+ */
+export type TranscendEventType = 'view-state-change';
+
+/** 'consent-change' custom event details */
+export type ViewStateEventDetails = {
+  /** The new view state */
+  viewState: ViewState;
 };
 
 /** Transcend Smart Quarantine API (window.transcend) */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -62,14 +62,16 @@ export type ConsentManagerAPI = Readonly<{
   EventTarget;
 
 /**
- * `transcend` event type
+ * `transcend` event types
  */
 export type TranscendEventType = 'view-state-change';
 
-/** 'consent-change' custom event details */
+/** 'view-state-change' custom event details */
 export type ViewStateEventDetails = {
-  /** The new view state */
+  /** The new, now-current view state */
   viewState: ViewState;
+  /** The previous view state */
+  previousViewState: ViewState | null;
 };
 
 /** Transcend Smart Quarantine API (window.transcend) */


### PR DESCRIPTION

Note: I've published an alpha version to NPM while working on a PR in consent-manager-ui.

## Related Issues

- T-20802 Add `transcend.getViewState()` API to CM UI

## Security Implications

_[none]_

## System Availability

_[none]_
