### PR TITLE
Add types for iab global vendor list v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.2.0",
+  "version": "10.2.1",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/iab.ts
+++ b/src/iab.ts
@@ -97,13 +97,13 @@ export type TcfV2VendorList = t.TypeOf<typeof TcfV2VendorList>;
 
 
 /**
-* TCF GVL v3 purpose configuration
-*/
+ * TCF GVL v3 purpose configuration
+ */
 export const TcfGvlV3Purpose = t.type({
- id: t.number,
- name: t.string,
- description: t.string,
- illustrations: t.array(t.string),
+  id: t.number,
+  name: t.string,
+  description: t.string,
+  illustrations: t.array(t.string),
 });
 
 /**
@@ -113,18 +113,18 @@ export type TcfGvlV3Purpose = t.TypeOf<typeof TcfGvlV3Purpose>;
 
 
 /**
-* TCF GVL v3 data categories configuration
-*/
+ * TCF GVL v3 data categories configuration
+ */
 export const TcfGvlV3DataCategory = t.type({
   id: t.number,
   name: t.string,
   description: t.string,
  });
  
- /**
-  * Type override
-  */
- export type TcfGvlV3DataCategory = t.TypeOf<typeof TcfGvlV3DataCategory>;
+/**
+ * Type override
+ */
+export type TcfGvlV3DataCategory = t.TypeOf<typeof TcfGvlV3DataCategory>;
  
 /**
  * TCF GVL v3 stack configuration
@@ -148,7 +148,9 @@ export const TcfGvlV3Vendor = t.intersection([
       purposes: t.record(t.string, t.number),
       specialPurposes: t.record(t.string, t.number),
     }),
-    urls: t.array(t.type({langId: t.string, privacy: t.string, legIntClaim: t.string})),
+    urls: t.array(
+      t.type({ langId: t.string, privacy: t.string, legIntClaim: t.string }),
+    ),
     dataDeclaration: t.array(t.number),
     deviceStorageDisclosureUrl: t.string,
   }),
@@ -182,6 +184,6 @@ export const TcfV3VendorList = t.intersection([
 ]);
 
 /**
-* Type override
-*/
+ * Type override
+ */
 export type TcfV3VendorList = t.TypeOf<typeof TcfV3VendorList>;

--- a/src/iab.ts
+++ b/src/iab.ts
@@ -118,7 +118,7 @@ export const TcfGvlV3DataCategory = t.type({
   name: t.string,
   description: t.string,
 });
- 
+
 /**
  * Type override
  */

--- a/src/iab.ts
+++ b/src/iab.ts
@@ -119,13 +119,13 @@ export const TcfGvlV3DataCategory = t.type({
   id: t.number,
   name: t.string,
   description: t.string,
- });
+});
  
 /**
  * Type override
  */
 export type TcfGvlV3DataCategory = t.TypeOf<typeof TcfGvlV3DataCategory>;
- 
+
 /**
  * TCF GVL v3 stack configuration
  */

--- a/src/iab.ts
+++ b/src/iab.ts
@@ -76,7 +76,7 @@ export const TcfVendorListVersion = t.type({
 export type TcfVendorListVersion = t.TypeOf<typeof TcfVendorListVersion>;
 
 /**
- * Contentful fields common between SaaSCategories and Catalogs
+ * TCF global vendor list version 2
  */
 export const TcfV2VendorList = t.intersection([
   TcfVendorListVersion,
@@ -91,6 +91,97 @@ export const TcfV2VendorList = t.intersection([
 ]);
 
 /**
- * Overload StoredContentfulEntry as a type
+ * Overload TcfV2VendorList as a type
  */
 export type TcfV2VendorList = t.TypeOf<typeof TcfV2VendorList>;
+
+
+/**
+* TCF GVL v3 purpose configuration
+*/
+export const TcfGvlV3Purpose = t.type({
+ id: t.number,
+ name: t.string,
+ description: t.string,
+ illustrations: t.array(t.string),
+});
+
+/**
+ * Type override
+ */
+export type TcfGvlV3Purpose = t.TypeOf<typeof TcfGvlV3Purpose>;
+
+
+/**
+* TCF GVL v3 data categories configuration
+*/
+export const TcfGvlV3DataCategory = t.type({
+  id: t.number,
+  name: t.string,
+  description: t.string,
+ });
+ 
+ /**
+  * Type override
+  */
+ export type TcfGvlV3DataCategory = t.TypeOf<typeof TcfGvlV3DataCategory>;
+ 
+/**
+ * TCF GVL v3 stack configuration
+ */
+export const TcfGvlV3Vendor = t.intersection([
+  t.type({
+    id: t.number,
+    name: t.string,
+    purposes: t.array(t.number),
+    legIntPurposes: t.array(t.number),
+    flexiblePurposes: t.array(t.number),
+    specialPurposes: t.array(t.number),
+    features: t.array(t.number),
+    specialFeatures: t.array(t.number),
+    cookieMaxAgeSeconds: t.union([t.number, t.null]),
+    usesCookies: t.boolean,
+    cookieRefresh: t.boolean,
+    usesNonCookieAccess: t.boolean,
+    dataRetention: t.type({
+      stdRetention: t.number,
+      purposes: t.record(t.string, t.number),
+      specialPurposes: t.record(t.string, t.number),
+    }),
+    urls: t.array(t.type({langId: t.string, privacy: t.string, legIntClaim: t.string})),
+    dataDeclaration: t.array(t.number),
+    deviceStorageDisclosureUrl: t.string,
+  }),
+  t.partial({
+    deletedDate: t.string,
+    overflow: t.type({
+      httpGetLimit: t.number,
+    }),
+  }),
+]);
+
+/**
+ * Type override
+ */
+export type TcfGvlV3Vendor = t.TypeOf<typeof TcfGvlV3Vendor>;
+
+/**
+ * TCF global vendor list version 3
+ */
+export const TcfV3VendorList = t.intersection([
+  TcfVendorListVersion,
+  t.type({
+    purposes: t.record(t.string, TcfGvlV3Purpose),
+    specialPurposes: t.record(t.string, TcfGvlV3Purpose),
+    features: t.record(t.string, TcfGvlV3Purpose),
+    specialFeatures: t.record(t.string, TcfGvlV3Purpose),
+    stacks: t.record(t.string, TcfStack),
+    dataCategories: t.record(t.string, TcfGvlV3DataCategory),
+    vendors: t.record(t.string, TcfGvlV3Vendor),
+  }),
+]);
+
+/**
+* Type override
+*/
+export type TcfV3VendorList = t.TypeOf<typeof TcfV3VendorList>;

--- a/src/iab.ts
+++ b/src/iab.ts
@@ -95,7 +95,6 @@ export const TcfV2VendorList = t.intersection([
  */
 export type TcfV2VendorList = t.TypeOf<typeof TcfV2VendorList>;
 
-
 /**
  * TCF GVL v3 purpose configuration
  */
@@ -110,7 +109,6 @@ export const TcfGvlV3Purpose = t.type({
  * Type override
  */
 export type TcfGvlV3Purpose = t.TypeOf<typeof TcfGvlV3Purpose>;
-
 
 /**
  * TCF GVL v3 data categories configuration


### PR DESCRIPTION
## Related Issues

- Links https://transcend.height.app/T-25617
- Creates new types for the updated IAB global vendor list version 3
- Updated documentation for the new vendor list: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md#global-vendor-list-and-tcf-policy-updates

## Security Implications

_[none]_

## System Availability

_[none]_
