### PR TITLE
Fix vendor list codec

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.4.2",
+  "version": "10.4.3",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/iab.ts
+++ b/src/iab.ts
@@ -141,11 +141,15 @@ export const TcfGvlV3Vendor = t.intersection([
     usesCookies: t.boolean,
     cookieRefresh: t.boolean,
     usesNonCookieAccess: t.boolean,
-    dataRetention: t.type({
-      stdRetention: t.number,
-      purposes: t.record(t.string, t.number),
-      specialPurposes: t.record(t.string, t.number),
-    }),
+    dataRetention: t.intersection([
+      t.type({
+        purposes: t.record(t.string, t.number),
+        specialPurposes: t.record(t.string, t.number),
+      }),
+      t.partial({
+        stdRetention: t.number,
+      }),
+    ]),
     urls: t.array(
       t.type({ langId: t.string, privacy: t.string, legIntClaim: t.string }),
     ),

--- a/src/iab.ts
+++ b/src/iab.ts
@@ -151,7 +151,12 @@ export const TcfGvlV3Vendor = t.intersection([
       }),
     ]),
     urls: t.array(
-      t.type({ langId: t.string, privacy: t.string, legIntClaim: t.string }),
+      t.intersection([
+        t.type({ langId: t.string, privacy: t.string }),
+        t.partial({
+          legIntClaim: t.string,
+        }),
+      ]),
     ),
     dataDeclaration: t.array(t.number),
     deviceStorageDisclosureUrl: t.string,


### PR DESCRIPTION
## Related Issues

- Fix TCF vendor list v3 codec. In vendors, retention list > stdRetention can be optional and urls > legIntClaim can be too.

## Security Implications

_[none]_

## System Availability

_[none]_
