### PR TITLE
Added back illustrations to tcf features

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.5.1",
+  "version": "10.5.2",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/iab.ts
+++ b/src/iab.ts
@@ -96,7 +96,7 @@ export const TcfV2VendorList = t.intersection([
 export type TcfV2VendorList = t.TypeOf<typeof TcfV2VendorList>;
 
 /**
- * TCF GVL v3 purpose configuration
+ * TCF GVL v3 purpose configuration (TCF features share the same type)
  */
 export const TcfGvlV3Purpose = t.type({
   id: t.number,
@@ -109,20 +109,6 @@ export const TcfGvlV3Purpose = t.type({
  * Type override
  */
 export type TcfGvlV3Purpose = t.TypeOf<typeof TcfGvlV3Purpose>;
-
-/**
- * TCF GVL v3 feature configuration
- */
-export const TcfGvlV3Feature = t.type({
-  id: t.number,
-  name: t.string,
-  description: t.string,
-});
-
-/**
- * Type override
- */
-export type TcfGvlV3Feature = t.TypeOf<typeof TcfGvlV3Feature>;
 
 /**
  * TCF GVL v3 data categories configuration
@@ -196,8 +182,8 @@ export const TcfV3VendorList = t.intersection([
   t.type({
     purposes: t.record(t.string, TcfGvlV3Purpose),
     specialPurposes: t.record(t.string, TcfGvlV3Purpose),
-    features: t.record(t.string, TcfGvlV3Feature),
-    specialFeatures: t.record(t.string, TcfGvlV3Feature),
+    features: t.record(t.string, TcfGvlV3Purpose),
+    specialFeatures: t.record(t.string, TcfGvlV3Purpose),
     stacks: t.record(t.string, TcfStack),
     dataCategories: t.record(t.string, TcfGvlV3DataCategory),
     vendors: t.record(t.string, TcfGvlV3Vendor),


### PR DESCRIPTION
## Related Issues

- undo https://github.com/transcend-io/airgap.js-types/pull/92
- Made mistake removing illustrations from TCF features (I was looking at the wrong version of the vendors list while doing this...)

## Security Implications

_[none]_

## System Availability

_[none]_
