### PR TITLE
add z-index config field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -183,6 +183,8 @@ export type RequiredConsentManagerConfig = t.TypeOf<
 export const OptionalConsentManagerConfig = t.partial({
   /** The set of enabled languages - CSV of ConsentManagerLanguageKey */
   languages: t.string,
+  /** The override value for the consent banner z-index */
+  uiZIndex: t.string,
 });
 
 /** type overload */


### PR DESCRIPTION
## Related Issues

links https://transcend.height.app/T-30079

## Internal Changelog

Context: Eventbrite took umbridge with the consent banner staying at the maximum z-index and blocking a payment modal of theirs

Fix: We added a new config option to allow for a manually specified z-index on the consent banner

Notes: We don't want to make this easy to enable, since in general "hiding" the consent banner like this is a bad pattern to follow. There may or may not be a better place to set this config value to better achieve that goal of making hiding sufficiently difficult (if there is, let me know)