### PR TITLE
add gpp enum to experience field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.7.0",
+  "version": "10.7.1",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/enums/experience.ts
+++ b/src/enums/experience.ts
@@ -178,6 +178,7 @@ export function defaultExperience(regime: PrivacyRegime): ExperienceInput {
           false,
       }),
     ),
+    iabSignals: [],
   };
 }
 

--- a/src/enums/experience.ts
+++ b/src/enums/experience.ts
@@ -119,6 +119,13 @@ export const RegionsOperator = makeEnum({
 export type RegionsOperator =
   typeof RegionsOperator[keyof typeof RegionsOperator];
 
+/**
+ * Set of IAB signals that we can communicate
+ */
+export enum IABSignal {
+  GppUsp = 'GPP_USP',
+}
+
 export interface ExperienceInput {
   /** The regime determining the default experience */
   name: PrivacyRegime;
@@ -138,6 +145,8 @@ export interface ExperienceInput {
   viewState: InitialViewState;
   /** experience purposes to be added */
   experiencePurposeInputs: ExperiencePurposeInput[];
+  /** set of IAB signals to be communicated in this experience */
+  iabSignals: IABSignal[];
 }
 
 /**


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-27026

## Internal Changelog

This is priming the type system to allow us to add sets of iab signals to the experiences object. I was a bit torn between where our source of truth for this enum was going to live - here vs cm-types vs ag-types - but ultimately I think it fits in well here since its main purpose will be to inform the new GPP load option. If you'd suggest somewhere else lmk