### PR TITLE
allow tcf ui to define a manual tcf string setter

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.7.4",
+  "version": "10.7.5",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.7.3",
+  "version": "10.7.4",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -61,6 +61,8 @@ export type ConsentManagerAPI = Readonly<{
     auth: AirgapAuth,
     options?: ShowConsentManagerOptions,
   ): Promise<void>;
+  /** Sets local tcf string (does not sync to xdi or preference store) */
+  setTCFConsent?: (tcString: string) => Promise<void>;
 }> &
   EventTarget;
 


### PR DESCRIPTION
## Internal Changelog

This allows customers to manually set their own TC string if they're using the TCF UI and also have their own consent database. This string won't be synced to the client-side or to the preference store due to a lack of user event associated with the update