### PR TITLE
improve types for airgap event listening

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.7.5",
+  "version": "10.7.6",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -208,22 +208,38 @@ export type AirgapAPI = Readonly<{
   getPrivacySignals(): Set<UserPrivacySignal>;
   /** airgap.js version number */
   version: string;
+  /** override the event listener signature for consent change events */
+  addEventListener: (
+    type: AirgapConsentEventType,
+    callback: ((evt: ConsentChangeEventDetails) => void) | null,
+    options?: boolean | AddEventListenerOptions | undefined,
+  ) => void;
 }> &
   EventTarget;
 
 /**
+ * Airgap event types that send the ConsentChangeEventDetails object with them
+ */
+export type AirgapConsentEventType =
+  | 'consent-change'
+  | 'sync'
+  | 'consent-resolution';
+
+/**
  * airgap.js event type
  */
-export type AirgapEventType = 'consent-change' | 'purpose-map-load';
+export type AirgapEventType = AirgapConsentEventType | 'purpose-map-load';
 
 /** 'consent-change' custom event details */
 export type ConsentChangeEventDetails = {
   /** The old tracking consent */
-  oldConsent: TrackingConsentDetails;
+  oldConsent: TrackingConsentDetails | null;
   /** The new tracking consent */
-  consent: TrackingConsentDetails;
+  consent: TrackingConsentDetails | null;
   /** The tracking consent diff (what's changed in the new consent) */
-  changes: ConsentChange | null;
+  changes: Record<string, boolean> | null;
+  /** Applicable privacy signals contributing to this consent change event */
+  signals?: Set<UserPrivacySignal> | null;
 };
 
 /** Removable process (can remove watchers, overrides, and protections) */

--- a/src/core.ts
+++ b/src/core.ts
@@ -130,6 +130,11 @@ export interface ReservedMetadata {
   tcmp: null | Record<string, unknown>;
 }
 
+/**
+ * Extra metadata to be synced along with consent
+ */
+export type Metadata = Record<string, unknown>;
+
 /** setConsent() options */
 export interface ConsentOptions {
   /** Was consent confirmed by the user? */
@@ -143,7 +148,7 @@ export interface ConsentOptions {
    * - `null` - Do not change metadata
    * - `false` - Clear metadata
    */
-  metadata?: (Record<string, unknown> & ReservedMetadata) | null | false;
+  metadata?: (Metadata & ReservedMetadata) | null | false;
   /** Last updated for metadata */
   metadataTimestamp?: string;
   /** Whether or not to return a Promise so that the caller can wait for sync to complete. By default, we do not wait for sync */


### PR DESCRIPTION
## Internal Changelog

These types were bugging me during development so I went ahead and updated them. This should make it so that if you call `airgap.addEventListener('consent-change', ...` (or any of the other consent change events) we'll properly detect that the subsequent callback will receive a `ConsentChangeEventDetails` object and you'll get static analysis on the callback block. Other events should be left unchanged.