### PR TITLE
create runtime types for reserved metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.7.7",
+  "version": "10.7.8",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -404,6 +404,16 @@ export const TrackingConsentWithNulls = t.record(
 /** Type override */
 export type TrackingConsentWithNulls = t.TypeOf<typeof TrackingConsent>;
 
+const TCFReservedMetadata = t.partial({
+  tcString: t.string,
+});
+
+const ReservedMetadata = t.partial({
+  tcmp: t.partial({
+    tcf: TCFReservedMetadata,
+  }),
+});
+
 const CoreTrackingConsentDetails = t.intersection([
   t.type({
     /**
@@ -420,7 +430,7 @@ const CoreTrackingConsentDetails = t.intersection([
     /** Whether or not the UI has been shown to the end-user (undefined in older versions of airgap.js) */
     prompted: t.boolean,
     /** Arbitrary metadata that customers want to be associated with consent state */
-    metadata: t.UnknownRecord,
+    metadata: t.intersection([ReservedMetadata, t.UnknownRecord]),
     /** When the metadata was last updated */
     metadataTimestamp: t.string,
   }),


### PR DESCRIPTION
## Internal Changelog

Creating a runtime type for our new reserved metadata, mostly so that we can pull it out in the lambda and store it in the preference store as a top level key
