### PR TITLE
reorg again to fix build size

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.7.8",
+  "version": "10.7.9",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,8 +3,13 @@ import type {
   RegimePurposeScopesConfig,
   TrackingPurpose,
 } from './core';
-import { BrowserLanguage } from './enums/browserLanguage';
-import { Region } from './experience';
+
+/* --------------------------------------------------------------------------------
+ * NOTE: PLEASE DON'T IMPORT ANYTHING BESIDES TYPES INTO THIS FILE.
+ * (or make -absolutely- certain it leaves a miniscule build footprint).
+ * Constants from this file are imported directly into airgap (core/init.ts)
+ * and if you import something that leaves traces it -will- bloat the airgap build.
+ * -------------------------------------------------------------------------------- */
 
 export const UNKNOWN_DEFAULT_EXPERIENCE = 'Unknown';
 
@@ -41,75 +46,6 @@ export const DEFAULT_EXPERIENCE_PURPOSE_SCOPES = Object.fromEntries(
     regimes.map((regime) => [regime, purposes]),
   ).flat(),
 );
-
-// default to []
-export const REGIME_REGIONS: Record<PrivacyRegime, Region[]> = {
-  CPRA: [{ country: 'US', countrySubDivision: 'US-CA' }],
-  GDPR: [
-    { country: 'EU' },
-    { country: 'GB' },
-    { country: 'NO' },
-    { country: 'IS' },
-    { country: 'LI' },
-  ],
-  LGPD: [{ country: 'BR' }],
-  CDPA: [{ country: 'US', countrySubDivision: 'US-VA' }],
-  CPA: [{ country: 'US', countrySubDivision: 'US-CO' }],
-  UCPA: [{ country: 'US', countrySubDivision: 'US-UT' }],
-  NEVADA_SB220: [{ country: 'US', countrySubDivision: 'US-NV' }],
-  nFADP: [{ country: 'CH' }],
-};
-
-// default to []
-export const REGIME_LANGUAGES: Record<PrivacyRegime, string[]> = {
-  GDPR: [
-    BrowserLanguage['Bulgarian (Bulgaria)'],
-    BrowserLanguage['Croatian (Croatia)'],
-    BrowserLanguage['Czech (Czech Republic)'],
-    BrowserLanguage['Danish (Denmark)'],
-    BrowserLanguage['Dutch (Belgium)'],
-    BrowserLanguage['Dutch (Netherlands)'],
-    BrowserLanguage['English (Ireland)'],
-    BrowserLanguage['Estonian (Estonia)'],
-    BrowserLanguage['Finnish (Finland)'],
-    BrowserLanguage['French (Belgium)'],
-    BrowserLanguage['French (France)'],
-    BrowserLanguage['French (Luxembourg)'],
-    BrowserLanguage['German (Austria)'],
-    BrowserLanguage['German (Germany)'],
-    BrowserLanguage['German (Liechtenstein)'],
-    BrowserLanguage['German (Luxembourg)'],
-    BrowserLanguage['Greek (Greece)'],
-    BrowserLanguage['Hungarian (Hungary)'],
-    BrowserLanguage['Icelandic (Iceland)'],
-    BrowserLanguage['Irish (Ireland)'],
-    BrowserLanguage['Italian (Italy)'],
-    BrowserLanguage['Latvian (Latvia)'],
-    BrowserLanguage['Lithuanian (Lithuania)'],
-    BrowserLanguage['Maltese (Malta)'],
-    BrowserLanguage['Norwegian (Norway)'],
-    BrowserLanguage['Norwegian Bokmål (Norway)'],
-    BrowserLanguage['Norwegian Nynorsk (Norway)'],
-    BrowserLanguage['Polish (Poland)'],
-    BrowserLanguage['Portuguese (Portugal)'],
-    BrowserLanguage['Romanian (Romania)'],
-    BrowserLanguage['Slovak (Slovakia)'],
-    BrowserLanguage['Slovenian (Slovenia)'],
-    BrowserLanguage['Spanish (Espa\u00f1a)'],
-    BrowserLanguage['Swedish (Finland)'],
-    BrowserLanguage['Swedish (Finland)'],
-    BrowserLanguage['Swedish (Sweden)'],
-  ],
-  LGPD: [BrowserLanguage['Portuguese (Brazil)']],
-  nFADP: [
-    BrowserLanguage['German (Switzerland)'],
-    BrowserLanguage['French (Switzerland)'],
-    BrowserLanguage['Italian (Switzerland)'],
-    BrowserLanguage['English (Switzerland)'],
-    BrowserLanguage['Portuguese (Switzerland)'],
-    BrowserLanguage['Swiss German (Switzerland)'],
-  ],
-};
 
 // default to []
 export const REGIME_TIMEZONES: Record<PrivacyRegime, string[]> = {};

--- a/src/experience.ts
+++ b/src/experience.ts
@@ -11,12 +11,10 @@ import { PrivacyRegime } from './core';
 import {
   DEFAULT_EXPERIENCE_PURPOSE_SCOPES,
   DEFAULT_EXPERIENCE_PURPOSE_OPT_OUTS,
-  REGIME_REGIONS,
   REGIME_DISPLAY_PRIORITY,
-  REGIME_LANGUAGES,
   REGIME_TIMEZONES,
 } from './constants';
-import { RegionsOperator } from './enums';
+import { BrowserLanguage, RegionsOperator } from './enums';
 
 export interface Region {
   /** A country's ISO code */
@@ -52,6 +50,77 @@ export interface ExperienceInput {
   /** experience purposes to be added */
   experiencePurposeInputs: ExperiencePurposeInput[];
 }
+
+// default to []
+// Don't put this into constants or you will regret it (per the constants.ts warning)
+export const REGIME_REGIONS: Record<PrivacyRegime, Region[]> = {
+  CPRA: [{ country: 'US', countrySubDivision: 'US-CA' }],
+  GDPR: [
+    { country: 'EU' },
+    { country: 'GB' },
+    { country: 'NO' },
+    { country: 'IS' },
+    { country: 'LI' },
+  ],
+  LGPD: [{ country: 'BR' }],
+  CDPA: [{ country: 'US', countrySubDivision: 'US-VA' }],
+  CPA: [{ country: 'US', countrySubDivision: 'US-CO' }],
+  UCPA: [{ country: 'US', countrySubDivision: 'US-UT' }],
+  NEVADA_SB220: [{ country: 'US', countrySubDivision: 'US-NV' }],
+  nFADP: [{ country: 'CH' }],
+};
+
+// default to []
+// Don't put this into constants or you will regret it (per the constants.ts warning)
+export const REGIME_LANGUAGES: Record<PrivacyRegime, string[]> = {
+  GDPR: [
+    BrowserLanguage['Bulgarian (Bulgaria)'],
+    BrowserLanguage['Croatian (Croatia)'],
+    BrowserLanguage['Czech (Czech Republic)'],
+    BrowserLanguage['Danish (Denmark)'],
+    BrowserLanguage['Dutch (Belgium)'],
+    BrowserLanguage['Dutch (Netherlands)'],
+    BrowserLanguage['English (Ireland)'],
+    BrowserLanguage['Estonian (Estonia)'],
+    BrowserLanguage['Finnish (Finland)'],
+    BrowserLanguage['French (Belgium)'],
+    BrowserLanguage['French (France)'],
+    BrowserLanguage['French (Luxembourg)'],
+    BrowserLanguage['German (Austria)'],
+    BrowserLanguage['German (Germany)'],
+    BrowserLanguage['German (Liechtenstein)'],
+    BrowserLanguage['German (Luxembourg)'],
+    BrowserLanguage['Greek (Greece)'],
+    BrowserLanguage['Hungarian (Hungary)'],
+    BrowserLanguage['Icelandic (Iceland)'],
+    BrowserLanguage['Irish (Ireland)'],
+    BrowserLanguage['Italian (Italy)'],
+    BrowserLanguage['Latvian (Latvia)'],
+    BrowserLanguage['Lithuanian (Lithuania)'],
+    BrowserLanguage['Maltese (Malta)'],
+    BrowserLanguage['Norwegian (Norway)'],
+    BrowserLanguage['Norwegian Bokmål (Norway)'],
+    BrowserLanguage['Norwegian Nynorsk (Norway)'],
+    BrowserLanguage['Polish (Poland)'],
+    BrowserLanguage['Portuguese (Portugal)'],
+    BrowserLanguage['Romanian (Romania)'],
+    BrowserLanguage['Slovak (Slovakia)'],
+    BrowserLanguage['Slovenian (Slovenia)'],
+    BrowserLanguage['Spanish (Espa\u00f1a)'],
+    BrowserLanguage['Swedish (Finland)'],
+    BrowserLanguage['Swedish (Finland)'],
+    BrowserLanguage['Swedish (Sweden)'],
+  ],
+  LGPD: [BrowserLanguage['Portuguese (Brazil)']],
+  nFADP: [
+    BrowserLanguage['German (Switzerland)'],
+    BrowserLanguage['French (Switzerland)'],
+    BrowserLanguage['Italian (Switzerland)'],
+    BrowserLanguage['English (Switzerland)'],
+    BrowserLanguage['Portuguese (Switzerland)'],
+    BrowserLanguage['Swiss German (Switzerland)'],
+  ],
+};
 
 /**
  * construct default experience for regime


### PR DESCRIPTION
## Changelog

The imports into `constants.ts` were bloating airgap.js core size, so we're moving them out into different folders
