### PR TITLE
Csmccarthy/tcf UI language config

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.12.0",
+  "version": "10.12.1",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -233,6 +233,8 @@ export const TCFBundledDataConfig = t.partial({
   nonTcfVendors: t.array(NonTcfVendor),
   /** Comma separated list of languages to support in the UI */
   languages: t.string,
+  /** Default locale to use for the UI internationalization  */
+  locale: t.string,
 });
 
 /** Type override */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -231,6 +231,8 @@ export const TCFBundledDataConfig = t.partial({
   restrictLegitimateInterestPurposes: t.array(t.number),
   /** Vendors that Transcend Consent regulates because they haven't registered with IAB TCF */
   nonTcfVendors: t.array(NonTcfVendor),
+  /** Comma separated list of languages to support in the UI */
+  languages: t.string,
 });
 
 /** Type override */


### PR DESCRIPTION
## Changelog

- Added in configuration options to support customization of the TCF UI's internationalization: a new `languages` key that supports filtering down your list of supported languages, and a `locale` key that sets the default locale to use for the translation.