### PR TITLE
Update GDPR default regional experience to include consent expiry

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.12.1",
+  "version": "10.12.2",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/experience.ts
+++ b/src/experience.ts
@@ -52,7 +52,7 @@ export interface ExperienceInput {
   /** Time in months after which a user's opt-in consent should expire */
   consentExpiry: number;
   /** Behavior to exhibit when the user's consent has expired */
-  onConsentExpiry: OnConsentExpiry; 
+  onConsentExpiry: OnConsentExpiry;
 }
 
 // default to []
@@ -132,9 +132,10 @@ export const REGIME_CONSENT_EXPIRY: Record<PrivacyRegime, number> = {
 };
 
 // default to prompt
-export const REGIME_ON_CONSENT_EXPIRY: Record<PrivacyRegime, OnConsentExpiry> = {
-  GDPR: OnConsentExpiry.ResetOptIns
-}
+export const REGIME_ON_CONSENT_EXPIRY: Record<PrivacyRegime, OnConsentExpiry> =
+  {
+    GDPR: OnConsentExpiry.ResetOptIns,
+  };
 
 /**
  * construct default experience for regime

--- a/src/experience.ts
+++ b/src/experience.ts
@@ -14,7 +14,7 @@ import {
   REGIME_DISPLAY_PRIORITY,
   REGIME_TIMEZONES,
 } from './constants';
-import { BrowserLanguage, RegionsOperator } from './enums';
+import { BrowserLanguage, OnConsentExpiry, RegionsOperator } from './enums';
 
 export interface Region {
   /** A country's ISO code */
@@ -49,6 +49,10 @@ export interface ExperienceInput {
   viewState: InitialViewState;
   /** experience purposes to be added */
   experiencePurposeInputs: ExperiencePurposeInput[];
+  /** Time in months after which a user's opt-in consent should expire */
+  consentExpiry: number;
+  /** Behavior to exhibit when the user's consent has expired */
+  onConsentExpiry: OnConsentExpiry; 
 }
 
 // default to []
@@ -122,6 +126,16 @@ export const REGIME_LANGUAGES: Record<PrivacyRegime, string[]> = {
   ],
 };
 
+// default to 0
+export const REGIME_CONSENT_EXPIRY: Record<PrivacyRegime, number> = {
+  GDPR: 12,
+};
+
+// default to prompt
+export const REGIME_ON_CONSENT_EXPIRY: Record<PrivacyRegime, OnConsentExpiry> = {
+  GDPR: OnConsentExpiry.ResetOptIns
+}
+
 /**
  * construct default experience for regime
  * @param regime - regime
@@ -150,6 +164,8 @@ export function defaultExperience(regime: PrivacyRegime): ExperienceInput {
           false,
       }),
     ),
+    consentExpiry: REGIME_CONSENT_EXPIRY[regime] ?? 0,
+    onConsentExpiry: REGIME_ON_CONSENT_EXPIRY[regime] ?? OnConsentExpiry.Prompt,
   };
 }
 


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-33233
- Adds `consentExpiry` and `onConsentExpiry` to experience defaults. Sets GDPR to `consentExpiry = 12` and `onConsentExpiry = ResetOptIns`
- Will follow up w/a PR to update the version of airgap.js-types in the monorepo + add tests to the createDefaultExperiences helper.

## Security Implications

_[none]_

## System Availability

_[none]_
