### PR TITLE
Expose consent manager UI version in ConsentManagerAPI.version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "10.12.3",
+  "version": "10.12.4",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -64,6 +64,8 @@ export type ConsentManagerAPI = Readonly<{
   ): Promise<void>;
   /** Sets local tcf string (does not sync to xdi or preference store) */
   setTCFConsent?: (auth: AirgapAuth, tcString: string) => Promise<void>;
+  /** UI version */
+  version?: string;
 }> &
   EventTarget;
 


### PR DESCRIPTION
With this change, our consent manager UI can expose its version through `transcend.version`

## Related Issues

- Blocks https://github.com/transcend-io/airgap.js-types/pull/130
- Links https://transcend.height.app/T-36217

## Security Implications

_[none]_

## System Availability

_[none]_
