### PR TITLE
Exposes transcend.getActiveLocale()

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "12.1.0",
+  "version": "12.2.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -97,6 +97,8 @@ export type ConsentManagerAPI = Readonly<{
   showConsentManager(options?: ShowConsentManagerOptions): Promise<void>;
   /** Set the current active language */
   setActiveLocale(locale: ConsentManagerLanguageKey): Promise<void>;
+  /** Get the currently active locale */
+  getActiveLocale: () => ConsentManagerLanguageKey
   /** Toggle consent manager */
   toggleConsentManager(options?: ShowConsentManagerOptions): Promise<void>;
   /** Hide consent manager */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -98,7 +98,7 @@ export type ConsentManagerAPI = Readonly<{
   /** Set the current active language */
   setActiveLocale(locale: ConsentManagerLanguageKey): Promise<void>;
   /** Get the currently active locale */
-  getActiveLocale: () => ConsentManagerLanguageKey
+  getActiveLocale: () => ConsentManagerLanguageKey;
   /** Toggle consent manager */
   toggleConsentManager(options?: ShowConsentManagerOptions): Promise<void>;
   /** Hide consent manager */


### PR DESCRIPTION
This is the inverset of `setActiveLocale` that already exists