### PR TITLE
Remove `SaleOfInfo` from LGPD and nFADP

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "12.4.0",
+  "version": "12.5.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,19 +14,13 @@ import type {
 export const UNKNOWN_DEFAULT_EXPERIENCE = 'Unknown';
 
 export const GDPR_PURPOSES: [PrivacyRegime[], TrackingPurpose[]] = [
-  ['GDPR'],
+  ['GDPR', 'LGPD', 'nFADP'],
   ['Advertising', 'Analytics', 'Functional'],
-];
-
-export const LGPD_NFADP_PURPOSES: [PrivacyRegime[], TrackingPurpose[]] = [
-  ['LGPD', 'nFADP'],
-  ['Advertising', 'Analytics', 'Functional', 'SaleOfInfo'],
 ];
 
 export const DEFAULT_REGIME_TRACKING_PURPOSE_SCOPES: RegimePurposeScopesConfig =
   [
     GDPR_PURPOSES,
-    LGPD_NFADP_PURPOSES,
     [['CPRA', 'CDPA', 'CPA', 'NEVADA_SB220', 'US_DNSS'], ['SaleOfInfo']],
     [
       [
@@ -39,7 +33,6 @@ export const DEFAULT_REGIME_TRACKING_PURPOSE_SCOPES: RegimePurposeScopesConfig =
 
 export const DEFAULT_REGIME_PURPOSE_OPT_OUTS: RegimePurposeScopesConfig = [
   GDPR_PURPOSES,
-  LGPD_NFADP_PURPOSES,
 ];
 
 export const DEFAULT_EXPERIENCE_PURPOSE_OPT_OUTS = Object.fromEntries(


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-22132
- Removes Sale of Info from default LGPD and nFADP regional experiences' purposes

## Security Implications

_[none]_

## System Availability

_[none]_
