### PR TITLE
Add autofocus as config for CM-UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "12.5.0",
+  "version": "12.6.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -241,6 +241,8 @@ export const OptionalConsentManagerConfig = t.partial({
    * Potential values: 'closed' (default) and 'open'
    */
   uiShadowRoot: t.string,
+  /** The override value for whether to focus on the first descendant of the root arg w/data-initialFocus attribute */
+  autofocus: t.boolean,
 });
 
 /** type overload */


### PR DESCRIPTION
## Related Issues

- Links https://transcend.height.app/T-40384
- Adds autofocus as a config for the consent manager ui. This config will control the initial focus state and the restore on close. Will follow up with PR to add this gate to the consent manager ui

## Security Implications

_[none]_

## System Availability

_[none]_
