### PR TITLE
Fix autofocus values

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "12.6.0",
+  "version": "12.7.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -241,11 +241,12 @@ export const OptionalConsentManagerConfig = t.partial({
    * Potential values: 'closed' (default) and 'open'
    */
   uiShadowRoot: t.string,
-  /** 
-   * The override value for whether to focus on the first descendant of the root arg w/data-initialFocus attribute 
-   * Potential values: 'on' (default) and 'off'
-   * */
-  autofocus: t.string,
+  /**
+   * The override value for whether to focus on the first descendant of the root arg w/data-initialFocus attribute
+   * Potential values: `'on'` (default) or `'off'`
+   *
+   */
+  autofocus: BooleanString,
 });
 
 /** type overload */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -241,8 +241,11 @@ export const OptionalConsentManagerConfig = t.partial({
    * Potential values: 'closed' (default) and 'open'
    */
   uiShadowRoot: t.string,
-  /** The override value for whether to focus on the first descendant of the root arg w/data-initialFocus attribute */
-  autofocus: t.boolean,
+  /** 
+   * The override value for whether to focus on the first descendant of the root arg w/data-initialFocus attribute 
+   * Potential values: 'on' (default) and 'off'
+   * */
+  autofocus: t.string,
 });
 
 /** type overload */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -16,7 +16,7 @@ import {
   PrivacyRegimeEnum,
   DismissedViewState,
 } from './enums';
-import { AirgapAuth, AirgapAuthMap } from './core';
+import { AirgapAuth, AirgapAuthMap, BooleanString } from './core';
 import { NonTcfVendor } from './iab';
 
 /** Transcend Smart Quarantine API (window.transcend) */


### PR DESCRIPTION
## Related Issues

- in reaction to https://github.com/transcend-io/consent-manager-ui/commit/8379d69a96a6ffaab676b01ad328920fdbec058a#r150041634
- Updates the values for autofocus to enable a more intuitive use of `data-autofocus`. Autofocus now takes a string.
- Will follow up with update in CM-UI and then monorepo

## Security Implications

_[none]_

## System Availability

_[none]_
