### PR TITLE
Add new states to DNSS experiences

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "12.7.0",
+  "version": "12.8.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/experience.ts
+++ b/src/experience.ts
@@ -82,6 +82,11 @@ export const REGIME_REGIONS: Record<PrivacyRegime, Region[]> = {
     { country: 'US', countrySubDivision: 'US-OR' },
     { country: 'US', countrySubDivision: 'US-MT' },
     { country: 'US', countrySubDivision: 'US-UT' },
+    { country: 'US', countrySubDivision: 'US-IA' },
+    { country: 'US', countrySubDivision: 'US-DE' },
+    { country: 'US', countrySubDivision: 'US-NH' },
+    { country: 'US', countrySubDivision: 'US-NE' },
+    { country: 'US', countrySubDivision: 'US-NJ' },
   ],
 };
 


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-41038
- Adds new states to the US DNSS experience: IA, DE, NH, NE, NH. Will follow up this PR with a package bump in the monorepo

## Security Implications

_[none]_

## System Availability

_[none]_
