### PR TITLE
add known purpose enum

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "12.8.1",
+  "version": "12.9.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/enums/purpose.ts
+++ b/src/enums/purpose.ts
@@ -51,6 +51,19 @@ export type ConfigurablePurpose =
   typeof ConfigurablePurpose[keyof typeof ConfigurablePurpose];
 
 /**
+ * Purposes that can be configured
+ */
+export const KnownDefaultPurpose = makeEnum({
+  /** The request is necessary for the essential features of the website */
+  Essential: 'Essential',
+  ...ConfigurablePurpose,
+});
+
+/** Type override */
+export type KnownDefaultPurpose =
+  typeof KnownDefaultPurpose[keyof typeof KnownDefaultPurpose];
+
+/**
  * Purposes used by the purpose map
  */
 export const Purpose = makeEnum({


### PR DESCRIPTION
## Related Issues

- links https://transcend.height.app/T-41185

## Changelog

This just adds an enum for known default purposes (i.e. all non-unknown purposes). This is pretty helpful across the board wherever we try to grab an organization's seeded purposes from the db, since we seed all the configurable purposes plus essential.