### PR TITLE
Export CoreTrackingConsentDetails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           fetch-depth: 100 # need the history to do a changed files check below (source, origin)
       - uses: actions/setup-python@v2
+        with:
+          python-version: '3.11'
       - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "12.9.0",
+  "version": "12.10.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -594,8 +594,7 @@ const ReservedMetadata = t.partial({
   }),
 });
 
-export const CoreTrackingConsentDetails =
- t.intersection([
+export const CoreTrackingConsentDetails = t.intersection([
   t.type({
     /**
      * Was tracking consent confirmed by the user?

--- a/src/core.ts
+++ b/src/core.ts
@@ -594,7 +594,8 @@ const ReservedMetadata = t.partial({
   }),
 });
 
-export const CoreTrackingConsentDetails = t.intersection([
+export const CoreTrackingConsentDetails =
+ t.intersection([
   t.type({
     /**
      * Was tracking consent confirmed by the user?

--- a/src/core.ts
+++ b/src/core.ts
@@ -594,7 +594,7 @@ const ReservedMetadata = t.partial({
   }),
 });
 
-const CoreTrackingConsentDetails = t.intersection([
+export const CoreTrackingConsentDetails = t.intersection([
   t.type({
     /**
      * Was tracking consent confirmed by the user?


### PR DESCRIPTION
## Related Issues

- closes [T-44386](https://transcend.height.app/T-44386)

## Internal Changelog

- Allows main repo to use `CoreTrackingConsentDetails`