### PR TITLE
Remove hardcoded python version on ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,6 @@ jobs:
         with:
           fetch-depth: 100 # need the history to do a changed files check below (source, origin)
       - uses: actions/setup-python@v2
-        with:
-          python-version: '3.11'
       - name: Use Node.js 20.x
         uses: actions/setup-node@v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ repos:
   - repo: https://github.com/pre-commit/mirrors-prettier
     # Use the sha / tag you want to point at, this needs
     # to stay in sync with the package.json version
-    rev: 'v2.3.2'
+    rev: v3.1.0
     hooks:
       - id: prettier
         args: [--write, --list-different]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: check-symlinks
@@ -31,5 +31,5 @@ repos:
         description: 'Run static code linting'
         entry: yarn lint --fix
         language: node
-        files: \.[jt]sx?$ # *.js, *.jsx, *.ts and *.tsx
+        files: .*\.(js|jsx|ts|tsx)$
         types: [file]

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "12.10.0",
+  "version": "12.10.1",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/enums/browserLanguage.ts
+++ b/src/enums/browserLanguage.ts
@@ -249,4 +249,4 @@ export const BrowserLanguage = makeEnum({
 
 /** Overrides type */
 export type BrowserLanguage =
-  typeof BrowserLanguage[keyof typeof BrowserLanguage];
+  (typeof BrowserLanguage)[keyof typeof BrowserLanguage];

--- a/src/enums/consentExpiry.ts
+++ b/src/enums/consentExpiry.ts
@@ -13,4 +13,4 @@ export const OnConsentExpiry = makeEnum({
 });
 /** Override type */
 export type OnConsentExpiry =
-  typeof OnConsentExpiry[keyof typeof OnConsentExpiry];
+  (typeof OnConsentExpiry)[keyof typeof OnConsentExpiry];

--- a/src/enums/experience.ts
+++ b/src/enums/experience.ts
@@ -12,4 +12,4 @@ export const RegionsOperator = makeEnum({
 });
 /** Override type */
 export type RegionsOperator =
-  typeof RegionsOperator[keyof typeof RegionsOperator];
+  (typeof RegionsOperator)[keyof typeof RegionsOperator];

--- a/src/enums/purpose.ts
+++ b/src/enums/purpose.ts
@@ -13,7 +13,7 @@ export const SpecialTrackingPurpose = makeEnum({
 
 /** Type override */
 export type SpecialTrackingPurpose =
-  typeof SpecialTrackingPurpose[keyof typeof SpecialTrackingPurpose];
+  (typeof SpecialTrackingPurpose)[keyof typeof SpecialTrackingPurpose];
 
 /**
  * Possible values for the default consent that can be given to a tracking purpose
@@ -30,7 +30,7 @@ export const DefaultConsentValue = makeEnum({
 
 /** Type override */
 export type DefaultConsentValue =
-  typeof DefaultConsentValue[keyof typeof DefaultConsentValue];
+  (typeof DefaultConsentValue)[keyof typeof DefaultConsentValue];
 
 /**
  * Purposes that can be configured
@@ -48,7 +48,7 @@ export const ConfigurablePurpose = makeEnum({
 
 /** Type override */
 export type ConfigurablePurpose =
-  typeof ConfigurablePurpose[keyof typeof ConfigurablePurpose];
+  (typeof ConfigurablePurpose)[keyof typeof ConfigurablePurpose];
 
 /**
  * Purposes that can be configured
@@ -61,7 +61,7 @@ export const KnownDefaultPurpose = makeEnum({
 
 /** Type override */
 export type KnownDefaultPurpose =
-  typeof KnownDefaultPurpose[keyof typeof KnownDefaultPurpose];
+  (typeof KnownDefaultPurpose)[keyof typeof KnownDefaultPurpose];
 
 /**
  * Purposes used by the purpose map
@@ -72,4 +72,4 @@ export const Purpose = makeEnum({
 });
 
 /** Type override */
-export type Purpose = typeof Purpose[keyof typeof Purpose];
+export type Purpose = (typeof Purpose)[keyof typeof Purpose];

--- a/src/enums/viewState.ts
+++ b/src/enums/viewState.ts
@@ -56,7 +56,7 @@ export const InitialTranscendViewState = makeEnum({
  * Type override
  */
 export type InitialTranscendViewState =
-  typeof InitialTranscendViewState[keyof typeof InitialTranscendViewState];
+  (typeof InitialTranscendViewState)[keyof typeof InitialTranscendViewState];
 
 /**
  * Consent Manager view states that can be used at launch
@@ -72,7 +72,7 @@ export const InitialViewState = makeEnum({
  * Type override
  */
 export type InitialViewState =
-  typeof InitialViewState[keyof typeof InitialViewState];
+  (typeof InitialViewState)[keyof typeof InitialViewState];
 
 /**
  * View states that are displayed in response to a user request (e.g. transcend.doNotSell() or )
@@ -88,7 +88,7 @@ export const ResponseViewState = makeEnum({
  * Type override
  */
 export type ResponseViewState =
-  typeof ResponseViewState[keyof typeof ResponseViewState];
+  (typeof ResponseViewState)[keyof typeof ResponseViewState];
 
 /**
  * Consent Manager view states that can be navigated to after initial view state
@@ -101,7 +101,7 @@ export const DeepViewState = makeEnum({
 /**
  * Type override
  */
-export type DeepViewState = typeof DeepViewState[keyof typeof DeepViewState];
+export type DeepViewState = (typeof DeepViewState)[keyof typeof DeepViewState];
 
 /**
  * Consent Manager view states after it's been dismissed
@@ -117,7 +117,7 @@ export const DismissedViewState = makeEnum({
  * Type override
  */
 export type DismissedViewState =
-  typeof DismissedViewState[keyof typeof DismissedViewState];
+  (typeof DismissedViewState)[keyof typeof DismissedViewState];
 
 /**
  * All possible view states of the Consent Manager
@@ -132,4 +132,4 @@ export const ViewState = makeEnum({
 /**
  * Type override
  */
-export type ViewState = typeof ViewState[keyof typeof ViewState];
+export type ViewState = (typeof ViewState)[keyof typeof ViewState];


### PR DESCRIPTION
## Related Issues

- removes [python 3.11](https://github.com/transcend-io/airgap.js-types/blob/main/.github/workflows/ci.yml#L54)

## Internal Change log

- Bumps pre-commit version.
- Bumps prettier.
- remove hard coded python version on ci.


