### PR TITLE
Mark `prompted` and `setPrompted` as deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Transcend Inc.",
   "name": "@transcend-io/airgap.js-types",
   "description": "TypeScript types for airgap.js interoperability with custom consent UIs",
-  "version": "12.12.2",
+  "version": "12.13.0",
   "homepage": "https://github.com/transcend-io/airgap.js-types",
   "repository": {
     "type": "git",

--- a/src/core.ts
+++ b/src/core.ts
@@ -145,7 +145,11 @@ export type Metadata = Record<string, unknown>;
 export interface ConsentOptions {
   /** Was consent confirmed by the user? */
   confirmed?: boolean;
-  /** Was the UI shown to the user? */
+  /** 
+   * Was the UI shown to the user?
+   * 
+   * @deprecated
+   */
   prompted?: boolean;
   /**
    * Extra metadata to be synced along with consent
@@ -264,7 +268,11 @@ export type AirgapAPI = Readonly<{
     /** Consent options */
     options?: ConsentOptions,
   ): Promise<boolean> | boolean;
-  /** Sets whether or not the Consent UI has been shown to the user */
+  /**
+   * Sets whether or not the Consent UI has been shown to the user
+   *
+   * @deprecated
+   */
   setPrompted(state: boolean): Promise<void>;
   /** Consents the user to all tracking purposes (requires recent UI interaction) */
   optIn(
@@ -608,7 +616,11 @@ export const CoreTrackingConsentDetails = t.intersection([
   t.partial({
     /** Has the consent been updated (including no-change confirmation) since default resolution */
     updated: t.boolean,
-    /** Whether or not the UI has been shown to the end-user (undefined in older versions of airgap.js) */
+    /**
+     * Whether or not the UI has been shown to the end-user (undefined in older versions of airgap.js)
+     *
+     * @deprecated
+     */
     prompted: t.boolean,
     /** Arbitrary metadata that customers want to be associated with consent state */
     metadata: t.intersection([ReservedMetadata, t.UnknownRecord]),


### PR DESCRIPTION
## Related Issues

- References [RES-163 setPrompted doesn't set the prompted value](https://linear.app/transcend/issue/RES-163/setprompted-doesnt-set-the-prompted-value)
